### PR TITLE
Extract creation of embeddings to dedicated class

### DIFF
--- a/personalized_active_learning/datasets/definitions/unhealthy.py
+++ b/personalized_active_learning/datasets/definitions/unhealthy.py
@@ -26,10 +26,6 @@ class UnhealthyDataset(BaseDataset):
         return "uc_texts_processed.csv"
 
     @property
-    def embeddings_path(self) -> Path:
-        return self.data_dir / f"embeddings/text_id_to_emb_{self.embeddings_type}.p"
-
-    @property
     def data_dir(self) -> Path:
         return DATA_DIR / "unhealthy_conversations"
 

--- a/personalized_active_learning/embeddings/__init__.py
+++ b/personalized_active_learning/embeddings/__init__.py
@@ -1,0 +1,2 @@
+"""Create text embeddings."""
+from .embeddings_creator import EmbeddingsCreator

--- a/personalized_active_learning/embeddings/embeddings_creator.py
+++ b/personalized_active_learning/embeddings/embeddings_creator.py
@@ -1,0 +1,90 @@
+# TODO: We can isolate dedicated class for each type (random, fasttext, etc.)
+# TODO: I don't think we have a time for that.
+
+"""Single class responsible for creation of each possible embedding."""
+import pickle
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import torch
+
+from settings import EMBEDDINGS_SIZES, TRANSFORMER_MODEL_STRINGS
+from utils import create_embeddings
+
+
+class EmbeddingsCreator:
+    """Create embeddings based on provided specification."""
+
+    def __init__(
+        self,
+        directory: Path,
+        embeddings_type: str,
+        use_cuda: bool,
+    ) -> None:
+        """Initialize object.
+
+        Args:
+            directory: The directory under which embeddings will be stored.
+            embeddings_type: Type of embeddings.
+            use_cuda: Whether to use CUDA during training.
+
+        """
+        if embeddings_type not in EMBEDDINGS_SIZES:
+            raise Exception(f"Embedding type {embeddings_type} is invalid.")
+        self.directory = directory
+        self.path = self.directory / f"text_id_to_emb_{embeddings_type}.p"
+        # TODO: Not sure why but CUDA might not be available here
+        # That was the same in original code
+        self.use_cuda = use_cuda and torch.cuda.is_available()
+        self.embeddings_type = embeddings_type
+
+    @property
+    def text_embedding_dim(self) -> int:
+        """Get the dimension of text embeddings.
+
+        Returns:
+            The dimension of text embeddings.
+
+        """
+        if self.embeddings_type not in EMBEDDINGS_SIZES:
+            raise NotImplementedError()
+
+        return EMBEDDINGS_SIZES[self.embeddings_type]
+
+    def get_embeddings(self, texts: List[str]) -> torch.Tensor:
+        """Get the texts embeddings.
+
+        Returns:
+            The text embeddings.
+
+        """
+        if not self.path.exists():
+            self._create_embeddings(texts)
+        return self._load_embeddings()
+
+    def _load_embeddings(self) -> torch.Tensor:
+        with open(self.path, "rb") as f:
+            text_idx_to_emb = pickle.load(f)
+
+        embeddings = []
+        for text_id in range(len(text_idx_to_emb.keys())):
+            embeddings.append(text_idx_to_emb[text_id])
+
+        embeddings = np.array(embeddings)
+        return torch.tensor(embeddings)
+
+    def _create_embeddings(self, texts: List[str]):
+        """Create embeddings under provided path if not already available."""
+
+        if self.embeddings_type in TRANSFORMER_MODEL_STRINGS:
+            model_name = TRANSFORMER_MODEL_STRINGS[self.embeddings_type]
+        else:
+            model_name = self.embeddings_type
+
+        create_embeddings(
+            texts,
+            self.path,
+            model_name=model_name,
+            use_cuda=self.use_cuda,
+        )

--- a/personalized_active_learning/embeddings/finetune.py
+++ b/personalized_active_learning/embeddings/finetune.py
@@ -1,0 +1,122 @@
+# TODO: UGLY! Refactor but I doubt we will have time for that
+import pickle
+from pathlib import Path
+
+import torch
+from pytorch_lightning import Callback
+from tqdm import tqdm
+
+from models import TransformerUserId
+from personalized_active_learning.learning.training import train_test
+from settings import TRANSFORMER_MODEL_STRINGS
+
+
+def fine_tune_embeddings(
+    original_dataset,  # type is BaseDataset, cannot be imported due to circular import
+    batch_size: int = 20,
+    epochs=3,
+    lr=2e-5,
+):
+    use_cuda = original_dataset.embeddings_creator.use_cuda
+    embeddings_type = original_dataset.embeddings_creator.embeddings_type
+    split_mode_str = original_dataset.split_mode.value
+    data_dir = original_dataset.embeddings_creator.directory
+    test_fold_index = original_dataset.test_fold_index
+
+    embeddings_path = data_dir / f"{embeddings_type}_{test_fold_index}_{split_mode_str}.p"
+    # IMPORTANT we need to change path in original creator
+    original_dataset.embeddings_creator.path = embeddings_path
+    # Embedding already created
+    if embeddings_path.exists():
+        return
+    # TODO: UGLY! Refactor but I doubt we will have time for that
+    dataset_cls = type(original_dataset)
+    init_kwargs = original_dataset.init_kwargs
+    init_kwargs["major_voting"] = True
+    init_kwargs["batch_size"] = batch_size
+    init_kwargs["use_finetuned_embeddings"] = False
+
+    dataset = dataset_cls(**init_kwargs)
+    model = TransformerUserId(
+        text_embedding_dim=original_dataset.embeddings_creator.text_embedding_dim,
+        output_dim=sum(original_dataset.classes_dimensions),
+        huggingface_model_name=TRANSFORMER_MODEL_STRINGS[embeddings_type],
+        max_length=128,
+        append_annotator_ids=False,
+        annotator_num=original_dataset.annotators_number,
+        use_cuda=use_cuda,
+    )
+
+    train_test(
+        dataset,
+        model=model,
+        epochs=epochs,
+        lr=lr,
+        use_cuda=use_cuda,
+        custom_callbacks=[
+            SaveEmbeddingCallback(
+                dataset=dataset,
+                save_path=embeddings_path,
+            )
+        ],
+    )
+
+
+class SaveEmbeddingCallback(Callback):
+    def __init__(
+        self,
+        dataset,  # type is BaseDataset, cannot be imported due to circular import
+        save_path: Path,
+    ):
+        self.dataset = dataset
+        self.save_path = save_path
+
+    def on_test_end(self, trainer, pl_module) -> None:
+        # TODO: Access to protected attributes
+        model = pl_module.model._model
+        tokenizer = pl_module.model._tokenizer
+        texts = self.dataset.data["text"].tolist()
+
+        embeddings = _get_embeddings(texts, tokenizer, model, use_cuda=True)
+        embeddings = embeddings.cpu().numpy()
+
+        text_idx_to_emb = {}
+        for i in range(embeddings.shape[0]):
+            text_idx_to_emb[i] = embeddings[i]
+
+        embeddings_path = self.save_path
+        if embeddings_path:
+            pickle.dump(text_idx_to_emb, open(embeddings_path, "wb"))
+
+
+def _get_embeddings(texts, tokenizer, model, max_seq_len=256, use_cuda=False):
+    def batch(iterable, n=1):
+        l = len(iterable)
+        for ndx in range(0, l, n):
+            yield iterable[ndx : min(ndx + n, l)]
+
+    if use_cuda:
+        device = "cuda"
+    else:
+        device = "cpu"
+
+    all_embeddings = []
+    for batched_texts in tqdm(batch(texts, 200), total=len(texts) / 200):
+        with torch.no_grad():
+            batch_encoding = tokenizer.batch_encode_plus(
+                batched_texts,
+                padding="longest",
+                add_special_tokens=True,
+                truncation=True,
+                max_length=max_seq_len,
+                return_tensors="pt",
+            ).to(device)
+
+            emb = model(**batch_encoding)
+
+        mask = batch_encoding["attention_mask"] > 0
+
+        for i in range(emb[0].size()[0]):
+            all_embeddings.append(emb[0][i, mask[i] > 0, :].mean(axis=0)[None, :])
+
+    return torch.cat(all_embeddings, dim=0).to("cpu")

--- a/personalized_active_learning/experiments/unhealthy.py
+++ b/personalized_active_learning/experiments/unhealthy.py
@@ -8,6 +8,7 @@ import active_learning.algorithms as algorithms
 from personalized_active_learning.active_learning_flows import StandardActiveLearningFlow
 from personalized_active_learning.datasets import UnhealthyDataset
 from personalized_active_learning.datasets.base import SplitMode
+from personalized_active_learning.embeddings import EmbeddingsCreator
 from personalized_active_learning.metrics.personal_metrics import (
     PersonalizedMetricsCallback,
 )
@@ -15,7 +16,7 @@ from personalized_active_learning.models import Baseline
 from personalized_nlp.utils import seed_everything
 from personalized_nlp.utils.experiments import product_kwargs
 import warnings
-
+from settings import DATA_DIR
 
 # False positive https://github.com/Lightning-AI/lightning/issues/11856
 warnings.filterwarnings("ignore", category=PossibleUserWarning)
@@ -25,7 +26,7 @@ os.environ["WANDB_START_METHOD"] = "thread"
 if __name__ == "__main__":
     wandb_project_name = "PNW_AL_Unhealthy"
     datamodule_cls = UnhealthyDataset
-
+    use_cuda = True
     activelearning_kwargs_list = product_kwargs(
         {
             "text_selector_cls": [
@@ -47,7 +48,13 @@ if __name__ == "__main__":
     )
     datamodule_kwargs_list = product_kwargs(
         {
-            "embeddings_type": ["labse"],
+            "embeddings_creator": [
+                EmbeddingsCreator(
+                    directory=DATA_DIR / "unhealthy_conversations" / "embeddings",
+                    embeddings_type="labse",
+                    use_cuda=use_cuda,
+                ),
+            ],
             "past_annotations_limit": [None],
             "split_mode": [SplitMode.TEXTS],
             "folds_num": [5],
@@ -71,7 +78,7 @@ if __name__ == "__main__":
         {
             "epochs": [20],
             "lr": [0.008],
-            "use_cuda": [True],
+            "use_cuda": [use_cuda],
             "monitor_metric": ["valid_loss"],
             "monitor_mode": ["max"],
         }

--- a/personalized_active_learning/learning/training.py
+++ b/personalized_active_learning/learning/training.py
@@ -5,13 +5,12 @@ import pytorch_lightning as pl
 import torch
 from pytorch_lightning.callbacks import ModelCheckpoint, TQDMProgressBar
 
-from personalized_active_learning.datasets import BaseDataset
 from personalized_nlp.learning.classifier import Classifier
 from settings import CHECKPOINTS_DIR
 
 
 def train_test(
-    datamodule: BaseDataset,
+    datamodule,  # type is BaseDataset, cannot be imported due to circular import
     model,
     epochs=6,
     lr=1e-2,


### PR DESCRIPTION
## Why?
* To simplify `BaseDataset` class.
* Slowly applying Dependency Injection Principle.

## This mr does two things:
* Extracts the creation of embeddings to dedicated class.
* Fixes the process of fine-tuning embeddings.

## :red_circle: Warning
* Currently the process of fine-tuning embeddings is quite convoluted. Please take a glance at [finetune_datamodule_embeddings](/home/cicheck/projects/studies/clarin/personalized-nlp/personalized_nlp/utils/finetune.py) it depends on `BaseDatamodule` which depends on `finetune_datamodule_embeddings`.
* To change that we would need quite a serious refactor. Refactor for which we don't have time I am afraid.
* So instead I decided to leave the fine-tuning process mostly unchanged (i.e. only copied code and delivered necessary fixes / adjustmend).