### PR TITLE
Refactor: ActiveLearningFlowBase and training

### DIFF
--- a/active_learning/callbacks/confidences.py
+++ b/active_learning/callbacks/confidences.py
@@ -20,3 +20,5 @@ class SaveConfidencesCallback(Callback):
         outputs = nn.Softmax(dim=1)(torch.cat(self._outputs))
 
         self.predict_outputs = outputs.cpu().numpy()
+        # Reset outputs - just one initialization of callback is needed
+        self._outputs = []

--- a/active_learning/experiments/unhealthy.py
+++ b/active_learning/experiments/unhealthy.py
@@ -96,7 +96,6 @@ if __name__ == "__main__":
             amount_per_user=activelearning_kwargs["amount_per_user"],
         )
         activelearning_kwargs["text_selector"] = text_selector
-
         trainer_kwargs["custom_callbacks"] = [
             PersonalizedMetricsCallback(),
         ]

--- a/personalized_active_learning/active_learning_flows/base.py
+++ b/personalized_active_learning/active_learning_flows/base.py
@@ -1,5 +1,4 @@
-# TODO: Refactor!!!
-from typing import Any, Dict, Optional
+from typing import Optional, List
 
 import pandas as pd
 
@@ -7,10 +6,11 @@ from personalized_active_learning.datasets import BaseDataset
 from personalized_active_learning.learning.training import train_test
 from personalized_active_learning.models import IModel
 from personalized_nlp.utils import seed_everything
-from pytorch_lightning import loggers as pl_loggers
-from settings import LOGS_DIR
 from active_learning.algorithms.base import TextSelectorBase
 from active_learning.callbacks.confidences import SaveConfidencesCallback
+from pytorch_lightning import loggers as pl_loggers
+from pytorch_lightning import Callback
+from settings import LOGS_DIR
 import abc
 
 
@@ -24,28 +24,95 @@ class ActiveLearningFlowBase(abc.ABC):
         self,
         dataset: BaseDataset,
         text_selector: TextSelectorBase,
-        datamodule_kwargs: dict,  # TODO: Should be removed
-        model: IModel,
-        train_kwargs: dict,  # TODO: Should be changed to Trainer
-        wandb_project_name: str,  # TODO: Pass already initialized logger
-        train_with_all_annotations=True,
-        stratify_by_user=False,
-        **kwargs,  # TODO: Remove, leftover to not break compatibility with old code
+        model_cls: IModel,
+        wandb_project_name: str,
+        logger_extra_metrics: dict,
+        monitor_metric: str,
+        monitor_mode: str,
+        epochs: int,
+        lr: float,
+        use_cuda: bool,
+        model_output_dim: int,
+        model_embedding_dim: int,
+        model_hidden_dims: Optional[List[int]] = None,
+        custom_callbacks: Optional[List[Callback]] = None,
+        stratify_by_user: bool = False,
     ) -> None:
-        self.model = model
-        self.dataset = dataset
+        """Base class for AL algorithm.
 
-        self.train_kwargs = train_kwargs
-        self.datamodule_kwargs = datamodule_kwargs
+        Class contains basic flow of algorithm with all common functions.
+        In a standard scenario only `experiment` method is needed to be
+        implemented.
 
-        self.wandb_project_name = wandb_project_name
+        If you want to add a new parameter, you need to add it to one of the
+        dictionaries below: global - `self.flow_params`; model - `self.model_params`;
+        trainer - `trainer_params`.
+
+        Args:
+            dataset (BaseDataset): A dataset which derives from the
+                `personalized_active_learning.datasets.base` class.
+            text_selector (TextSelectorBase): A text selector which derives from
+                `active_learning.algorithms.base` class. Selects annotations from dataset.
+            model_cls (IModel): A model defined in `personalized_active_learning.models`
+                directory. Used for a main training. (Imorted definition, eg. `Baseline`).
+            wandb_project_name (str): A name of the experiment.
+            logger_extra_metrics (dict): Dictionary with extra metrics for logger.
+                By default `datamodule_kwargs` should be passed
+            monitor_metric (str): Monitor argument for `ModelCheckpoint`.
+                https://keras.io/api/callbacks/model_checkpoint/
+            monitor_mode (str): Mode argument for `ModelCheckpoint`
+                  https://keras.io/api/callbacks/model_checkpoint/
+            epochs (int): Number of training epochs. Used in `training` module.
+            lr (float): Learning rate for a model. Used in `training` module.
+            use_cuda (bool): Use cuda. Used in `training` module.
+            model_output_dim (int): Output dimension used in `model_cls` initialization
+            model_embedding_dim (int): Embeding dimension used in `model_cls`
+                initialization.
+            model_hidden_dims Optional[List[int]]: Hidden dimensions sizes used in
+                `model_cls`initialization. Defaults to None.
+            custom_callbacks (Optional[List[Callback]]): A list with custom callbacks for
+                `Trainer`.
+            `SaveConfidencesCallback`, `ModelCheckpoint` and `TQDMProgressBar` are
+            always added. Defaults to None.
+            stratify_by_user (bool, optional): Stratify data by user. Defaults to False.
+        """
+
         self.confidences = None
-        self.train_with_all_annotations = train_with_all_annotations
+        self.dataset = dataset
+        self.logger_extra_metrics = logger_extra_metrics
+        self.wandb_project_name = wandb_project_name
         self.stratify_by_user = stratify_by_user
+        self.text_selector = text_selector
+        self.model_cls = model_cls
         annotations = dataset.annotations
+
         annotations.loc[annotations.split.isin(["train"]), "split"] = "none"
 
-        self.text_selector = text_selector
+        if not custom_callbacks:
+            custom_callbacks = []
+
+        self.confidences_callback = SaveConfidencesCallback()
+        custom_callbacks.append(self.confidences_callback)
+
+        # Arguments passed in train_model
+        self.flow_params = {
+            "datamodule": dataset,
+        }
+
+        self.model_params = {
+            "output_dim": model_output_dim,
+            "embeding_dim": model_embedding_dim,
+            "hidden_dims": model_hidden_dims  # Added for future
+        }
+
+        self.trainer_params = {
+            "epochs": epochs,
+            "lr": lr,
+            "use_cuda": use_cuda,
+            "monitor_metric": monitor_metric,
+            "monitor_mode": monitor_mode,
+            "custom_callbacks": custom_callbacks,
+        }
 
     def add_annotations(self, amount: int):
         """Annotate texts.
@@ -84,17 +151,14 @@ class ActiveLearningFlowBase(abc.ABC):
         annotations = self.dataset.annotations
         annotations.loc[selected_annotations.index, "split"] = "train"
 
-    def train_model(self, additional_hparams: Optional[Dict[str, Any]] = None):
+    def train_model(self) -> None:
+        """Run single iteration of AL algorithm.
+
+        Prepare logger, run training and save metrics. As a result `self.confidences`
+        are updated.
+        """
+
         dataset = self.dataset
-        datamodule_kwargs = dict(self.datamodule_kwargs)
-        train_kwargs = dict(self.train_kwargs)
-
-        confidences_callback = SaveConfidencesCallback()
-        if "custom_callbacks" in train_kwargs:
-            train_kwargs["custom_callbacks"].append(confidences_callback)
-        else:
-            train_kwargs["custom_callbacks"] = [confidences_callback]
-
         annotations = self.dataset.annotations
         annotated_annotations = annotations[annotations.split.isin(["train"])]
         annotated_texts_number = annotated_annotations.text_id.nunique()
@@ -109,7 +173,7 @@ class ActiveLearningFlowBase(abc.ABC):
             annotated_annotations["annotator_id"].value_counts().median()
         )
 
-        hparams = {
+        lparams = {
             "dataset": type(dataset).__name__,
             "annotation_amount": self.annotated_amount,
             "text_selector": type(self.text_selector).__name__,
@@ -118,34 +182,33 @@ class ActiveLearningFlowBase(abc.ABC):
             "mean_positive": mean_positive,
             "median_annotations_per_user": median_annotations_per_user,
             "stratify_by_user": self.stratify_by_user,
-            **datamodule_kwargs,
-            **train_kwargs,
+            **self.logger_extra_metrics,
+            **self.trainer_params
         }
-
-        if additional_hparams is not None:
-            hparams.update(additional_hparams)
 
         logger = pl_loggers.WandbLogger(
             save_dir=str(LOGS_DIR),
-            config=hparams,
+            config=lparams,
             project=self.wandb_project_name,
             log_model=False,
         )
 
-        seed_everything(24)
+        seed_everything()  # Model's weights initialization
+        model = self.model_cls(
+            **self.model_params,
+        )
         trainer = train_test(
-            dataset,
-            model=self.model,
+            model=model,
             logger=logger,
-            **train_kwargs,
+            **self.flow_params,
+            **self.trainer_params
         )
 
         if any(dataset.annotations.split == "none"):
-            # gather confidence levels
+            # Gather confidence levels
             not_annotated_dataloader = dataset.custom_dataloader("none", shuffle=False)
             trainer.predict(dataloaders=not_annotated_dataloader, ckpt_path="best")
-
-            self.confidences = confidences_callback.predict_outputs
+            self.confidences = self.confidences_callback.predict_outputs
 
         logger.experiment.finish()
 
@@ -154,7 +217,8 @@ class ActiveLearningFlowBase(abc.ABC):
         """Run AL.
 
         Args:
-            max_amount: Maximum number of texts that should be annotated before AL is stopped.
+            max_amount: Maximum number of texts that should be annotated before AL is
+                stopped.
             step_size: The number of texts that should be annotated in each AL cycle.
 
         """

--- a/personalized_active_learning/active_learning_flows/definitions/standard.py
+++ b/personalized_active_learning/active_learning_flows/definitions/standard.py
@@ -10,7 +10,6 @@ class StandardActiveLearningFlow(ActiveLearningFlowBase):
         self,
         max_amount: int,
         step_size: int,
-        **kwargs,  # TODO: Leftover to not break compatibility with old code
     ):
         """Run AL.
 

--- a/personalized_active_learning/experiments/unhealthy.py
+++ b/personalized_active_learning/experiments/unhealthy.py
@@ -25,7 +25,7 @@ os.environ["CUDA_VISIBLE_DEVICES"] = "1"
 os.environ["WANDB_START_METHOD"] = "thread"
 
 if __name__ == "__main__":
-    wandb_project_name = "test_s"
+    wandb_project_name = "PNW_AL_Unhealthy"
     datamodule_cls = UnhealthyDataset
     model_cls = Baseline
     use_cuda = True

--- a/personalized_active_learning/models/definitions/baseline.py
+++ b/personalized_active_learning/models/definitions/baseline.py
@@ -9,7 +9,7 @@ class Baseline(IModel):
         self,
         output_dim=2,
         text_embedding_dim=768,
-        **kwargs,  # TODO: eliminate kwargs
+        **kwargs,  # TODO: eliminate kwargs / We need it to define different models
     ):
         super().__init__()
         self.text_embedding_dim = text_embedding_dim


### PR DESCRIPTION
What is done:
- `ActiveLearningFlowBase` **kwargs are gone
-  Trainer cleaned up
- Added typing and docstrings

Problems:
- Model cannot be moved to experiments. We need to init model in train loop.
- Seed_everything in `ActiveLearningFlowBase`  is important for model's weights initialization
- Logger should be initialized in ALFlowBase - each AL loop should return a result
- Trainer needs to be defined in `training`. Moving it to parent does not make sense.

