### PR TITLE
refactor: Integration with python3.8

### DIFF
--- a/personalized_active_learning/integration_tools/__init__.py
+++ b/personalized_active_learning/integration_tools/__init__.py
@@ -1,0 +1,1 @@
+from .pairwise_impl import pairwise

--- a/personalized_active_learning/integration_tools/pairwise_impl.py
+++ b/personalized_active_learning/integration_tools/pairwise_impl.py
@@ -1,0 +1,18 @@
+from itertools import tee
+from typing import Iterable
+
+def pairwise(iterable: Iterable) -> Iterable:
+    """Pairwise implementation in case of using > python3.10.
+
+    Based on official implementation: 
+    https://docs.python.org/3/library/itertools.html#itertools.pairwise
+
+    Args:
+        iterable (Iterable): Any iterable object
+    Returns:
+        Iterable: pairwise('ABCDEFG') --> AB BC CD DE EF FG 
+    """
+
+    a, b = tee(iterable)
+    next(b, None)
+    return zip(a, b)

--- a/personalized_active_learning/models/definitions/naive/mlp.py
+++ b/personalized_active_learning/models/definitions/naive/mlp.py
@@ -1,11 +1,15 @@
 from collections import OrderedDict
-from itertools import pairwise
-from typing import Optional
+from typing import Optional, List
 
 import torch.nn as nn
 
 from personalized_active_learning.datamodules import TextFeaturesBatch
 from personalized_active_learning.models.interface import IModel
+
+try:
+    from itertools import pairwise
+except ImportError:
+    from personalized_active_learning.integration_tools import pairwise
 
 
 class Mlp(IModel):
@@ -13,7 +17,7 @@ class Mlp(IModel):
         self,
         output_dim: int = 2,
         text_embedding_dim: int = 768,
-        hidden_sizes: Optional[list[int]] = None,
+        hidden_sizes: Optional[List[int]] = None,
         dropout: float = 0.2,
         **kwargs,
     ):

--- a/personalized_active_learning/models/definitions/personalized/personalized_mlp.py
+++ b/personalized_active_learning/models/definitions/personalized/personalized_mlp.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
-from itertools import pairwise
-from typing import Optional
+from typing import Optional, List
 
 import torch
 import torch.nn as nn
@@ -8,13 +7,18 @@ import torch.nn as nn
 from personalized_active_learning.datamodules import TextFeaturesBatch
 from personalized_active_learning.models.interface import IModel
 
+try:
+    from itertools import pairwise
+except ImportError:
+    from personalized_active_learning.integration_tools import pairwise
+
 
 class PersonalizedMlp(IModel):
     def __init__(
         self,
         output_dim: int = 2,
         text_embedding_dim: int = 768,
-        hidden_sizes: Optional[list[int]] = None,
+        hidden_sizes: Optional[List[int]] = None,
         dropout: float = 0.2,
         **kwargs,
     ):


### PR DESCRIPTION
What?
- Added custom implementation of `pairwise`
- Typing refactor

Why?
There is python3.8 on worker4k. 